### PR TITLE
docker: make SSR service available in MW network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 SSR_PORT=3030
+MEDIAWIKI_NETWORK_TO_JOIN=addshoremediawikidockerdev_default
 CSR_PORT=8080
 NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ User interface for managing terms in Wikibase
 
 ## Configuring
 * set the server-specific environment variables: `cp .env.example .env` and modify `.env` accordingly
+  * `SSR_PORT` is the port at which you can reach the node server performing server-side vue rendering
+  * `MEDIAWIKI_NETWORK_TO_JOIN` is the (local docker) network the SSR service should be attached to in order to make it available to wikibase. If you set this, the SSR service will be available inside of this network at http://node-ssr:<SSR_PORT from your .env file>
+  * `CSR_PORT` is the port at which you can reach the development server
+  * `NODE_ENV` is the environment to set for node.js
 
 ## Building
 * `docker-compose run --rm node npm run build` builds the frontend code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,13 @@ services:
     ports:
       - '${SSR_PORT}:${SSR_PORT}'
     command: 'node serverBuild/server.js'
+    networks:
+      mediawiki_dev_network:
+        aliases:
+          - 'node-ssr'
+      default: ~
+
+networks:
+  mediawiki_dev_network:
+    external:
+      name: '${MEDIAWIKI_NETWORK_TO_JOIN}'


### PR DESCRIPTION
Allow for wikibase (e.g. in the mediawiki development enviroment) to
reach the SSR service by making it available in a docker network
configurable in the .env file.
Works for example with https://github.com/addshore/mediawiki-docker-dev/