### PR TITLE
Check in CSS build

### DIFF
--- a/dist/wikibase.termbox.main.css
+++ b/dist/wikibase.termbox.main.css
@@ -1,0 +1,1 @@
+.termbox-placeholder{background:#ccc;width:100%;height:100px}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "NODE_ENV=production vue-cli-service build",
     "build-server": "WEBPACK_TARGET=node vue-cli-service build --mode server && tsc --p src/server",
     "lint": "vue-cli-service lint --no-fix",
     "fix": "vue-cli-service lint",


### PR DESCRIPTION
The CSS build previously got lost because the `NODE_ENV` variable was set to development during the build command. This should never happen so we might as well always set it to `production` within the command.