### PR TITLE
Remove `--mode server` for the build-server npm command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "NODE_ENV=production vue-cli-service build",
-    "build-server": "WEBPACK_TARGET=node vue-cli-service build --mode server && tsc --p src/server",
+    "build-server": "WEBPACK_TARGET=node vue-cli-service build && tsc --p src/server",
     "lint": "vue-cli-service lint --no-fix",
     "fix": "vue-cli-service lint",
     "test": "vue-cli-service test:unit"


### PR DESCRIPTION
`--mode server` does not actually do anything for us. `--mode` can be used to load different environment configs, but we're not actually doing that. Reference: https://cli.vuejs.org/guide/mode-and-env.html#modes