### PR TITLE
T208226 jsduck: add (disabling) configuration

### DIFF
--- a/jsduck.json
+++ b/jsduck.json
@@ -1,0 +1,10 @@
+{
+	"--title": "Wikibase Termbox - Documentation",
+	"--output": "docs",
+	"--processes": "0",
+	"--warnings-exit-nonzero": true,
+	"--builtin-classes": true,
+	"--warnings": ["-all"],
+	"--": [
+	]
+}


### PR DESCRIPTION
ES6 syntax is not supported[0] which is causing problems when building the
entire project and so far it is not clear what we want to go into the
documentation anyhow.
[0] https://github.com/senchalabs/jsduck/issues/630

Bug: https://phabricator.wikimedia.org/T208226

Try via 
```
docker run -it --rm -v $(pwd):/workdir tozny/jsduck jsduck