### PR TITLE
Add tslint rules for yoda expressions and variable names

### DIFF
--- a/tslint-wikimedia-eslint-rules-port.json
+++ b/tslint-wikimedia-eslint-rules-port.json
@@ -66,12 +66,13 @@
         "error": "Error"
       }
     } ],
-    "yoda": [ "error", "never" ],
 
     "space-within-parens": [true, 1],
     "eofline": true,
     "no-misused-new": true,
     "no-unused-expression": true,
-    "no-consecutive-blank-lines": true
+    "no-consecutive-blank-lines": true,
+    "variable-name": [true, "ban-keywords", "check-format"],
+    "binary-expression-operand-order": true
   }
 }


### PR DESCRIPTION
`"binary-expression-operand-order": true` prevents expressions like `false === foo` and the like.
`"variable-name": [true, "ban-keywords", "check-format"]` limits variable names to lowerCamelCase or UPPER_CASE and disallows keywords.

I didn't find a way to limit naming for method and class/interface property names. If someone finds something, please add that.