### PR TITLE
docker-compose: document need for correct .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ User interface for managing terms in Wikibase
 ## Configuring
 * set the server-specific environment variables: `cp .env.example .env` and modify `.env` accordingly
   * `SSR_PORT` is the port at which you can reach the node server performing server-side vue rendering
-  * `MEDIAWIKI_NETWORK_TO_JOIN` is the (local docker) network the SSR service should also be attached to in order to make it available to wikibase. If you set this, the SSR service will be available inside of this network at http://node-ssr:<SSR_PORT from your .env file>. This can be used in conjunction with e.g. https://github.com/addshore/mediawiki-docker-dev/
+  * `MEDIAWIKI_NETWORK_TO_JOIN` is the (local docker) network the SSR service should also be attached to in order to make it available to wikibase. The SSR service can be reached inside of this network at http://node-ssr:<SSR_PORT from your .env file>. This can be used in conjunction with e.g. https://github.com/addshore/mediawiki-docker-dev/
+    > ⚠ Some versions of `docker-compose` insist this network exists. Make sure to set this value to an existing docker network (either created by another `docker-compose` project or you manually) - check via `docker network ls`
   * `CSR_PORT` is the port at which you can reach the development server
   * `NODE_ENV` is the environment to set for node.js
 


### PR DESCRIPTION
We observed some versions of docker-compose (e.g. 1.19.1) to fail when
MEDIAWIKI_NETWORK_TO_JOIN was set to an empty string while others
(e.g. 1.17.1) created a custom, prefixed network instead. Added a
warning.