### PR TITLE
container node: ensure right user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 
 install:
   - cp .env.example .env
+  - docker-compose build --build-arg UID=$(id -u) --build-arg GID=$(id -g) node
   - docker-compose run --rm node npm ci
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:8.12
+
+ARG UID=1000
+ARG GID=1000
+
+RUN usermod -u $UID node
+RUN groupmod -g $GID node
+
+USER node

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 User interface for managing terms in Wikibase
 
 ## Installation
-* `docker-compose run --rm node npm install`
+```
+# ensure the node user uses your user id, so you own generated files
+docker-compose build --build-arg UID=$(id -u) --build-arg GID=$(id -g) node
+```
+
+```
+# install npm dependencies
+docker-compose run --rm node npm install
+  ```
 
 ## Configuring
 * set the server-specific environment variables: `cp .env.example .env` and modify `.env` accordingly

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '2'
 
 services:
   node:
-    image: 'node:8.12'
+    build:
+      context: ./
+    image: wmde/wikibase-termbox-node
     volumes:
       - '~/.npm:/.npm'
       - './:/app'


### PR DESCRIPTION
The node docker image comes with a 'node' user that can (and should) be
used instead of root. Setting its user id to the one of your user on the
host system ensures that files generated into the mounted volumes are
owned by you.
Make sure to give the README another read!

See https://github.com/nodejs/docker-node/blob/526c6e618300bdda0da4b3159df682cae83e14aa/8/jessie/Dockerfile#L3

Interestingly, even though we've been running npm through the container before, I now see changes to `package-lock.json` after running `npm install` (`"optional": true` stuff) - not sure yet, if we should check that in or not.