### PR TITLE
TermboxRequest: provide interface

### DIFF
--- a/src/common/interfaces/TermboxRequest.ts
+++ b/src/common/interfaces/TermboxRequest.ts
@@ -1,0 +1,6 @@
+import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
+
+export default interface TermboxRequest {
+	getLanguage(): string;
+	getEntity(): FingerprintableEntity;
+}


### PR DESCRIPTION
Adds interface to be implemented by both client and server to describe
state to be committed to app store. Code thereafter should be identical.
I would not mind if we come up with a better folder name as soon as patterns emerge.

Bug: T209283