### PR TITLE
WikibaseRepo: add way to get entity on server (api)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,9 @@
 module.exports = {
+  globals: {
+    'ts-jest': {
+      tsConfigFile: './tsconfig.all.json',
+    },
+  },
   moduleFileExtensions: [
     'js',
     'jsx',
@@ -23,4 +28,4 @@ module.exports = {
     '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)'
   ],
   testURL: 'http://localhost/'
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1604,7 +1604,6 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
       "requires": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
@@ -2086,7 +2085,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -2131,8 +2129,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -2176,8 +2173,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -2250,14 +2246,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -2660,7 +2654,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -2700,8 +2693,7 @@
     "bluebird": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
-      "dev": true
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -3171,8 +3163,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "1.1.3",
@@ -3513,8 +3504,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "coa": {
       "version": "2.0.1",
@@ -3579,14 +3569,12 @@
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4050,8 +4038,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.0.6",
@@ -4493,7 +4480,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -4714,8 +4700,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -4931,7 +4916,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -5317,8 +5301,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -5362,14 +5345,12 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-glob": {
       "version": "2.2.3",
@@ -5700,8 +5681,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5888,8 +5868,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "0.4.10",
@@ -5944,7 +5923,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
@@ -5955,7 +5933,6 @@
           "version": "1.0.6",
           "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -6665,7 +6642,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -6820,14 +6796,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-      "dev": true,
       "requires": {
         "ajv": "^5.3.0",
         "har-schema": "^2.0.0"
@@ -7488,7 +7462,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -8035,8 +8008,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -8095,8 +8067,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
       "version": "1.3.7",
@@ -9200,8 +9171,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "11.12.0",
@@ -9252,20 +9222,17 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.2",
@@ -9298,7 +9265,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -10092,6 +10058,16 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "mwbot": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/mwbot/-/mwbot-1.0.10.tgz",
+      "integrity": "sha1-pEC9ZmOnYoq1t5lgnpjLL8ThM8k=",
+      "requires": {
+        "bluebird": "^3.4.6",
+        "request": "^2.75.0",
+        "semlog": "^0.6.10"
+      }
+    },
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
@@ -10484,8 +10460,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -11037,8 +11012,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "3.0.0",
@@ -11965,6 +11939,22 @@
         }
       }
     },
+    "prettyjson": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
+      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "requires": {
+        "colors": "^1.1.2",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -12038,8 +12028,7 @@
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
-      "dev": true
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -12782,7 +12771,6 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -13456,6 +13444,15 @@
         "node-forge": "0.7.5"
       }
     },
+    "semlog": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/semlog/-/semlog-0.6.10.tgz",
+      "integrity": "sha1-DyJa6o6zwvJM6TWNhnjQ9Bp/4Fs=",
+      "requires": {
+        "chalk": "^1.1.3",
+        "prettyjson": "^1.1.3"
+      }
+    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -13942,7 +13939,6 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
       "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -14531,7 +14527,6 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -14540,8 +14535,7 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
@@ -15043,7 +15037,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -15051,8 +15044,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -15540,8 +15532,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -15568,7 +15559,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^6.1.0",
     "express": "^4.16.4",
     "module-alias": "^2.1.0",
+    "mwbot": "^1.0.10",
     "vue": "^2.5.17",
     "vue-class-component": "^6.0.0",
     "vue-property-decorator": "^7.0.0",

--- a/src/server/data-access/MwBotWikibaseRepo.ts
+++ b/src/server/data-access/MwBotWikibaseRepo.ts
@@ -1,0 +1,61 @@
+import WikibaseRepo from '@/server/data-access/WikibaseRepo';
+import mwbot from 'mwbot';
+import TechnicalProblem from '@/server/data-access/error/TechnicalProblem';
+import EntityNotFound from '@/server/data-access/error/EntityNotFound';
+import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
+import EntityInitializer from '@/common/EntityInitializer';
+
+export default class MwBotWikibaseRepo implements WikibaseRepo {
+	private bot: mwbot;
+	private entityInitializer: EntityInitializer;
+
+	public constructor( bot: mwbot, entityInitializer: EntityInitializer ) {
+		this.bot = bot;
+		this.entityInitializer = entityInitializer;
+	}
+
+	private getEntity( id: string ): Promise<any> {
+		return new Promise( ( resolve, reject ) => {
+			this.bot.request( {
+				ids: id,
+				action: 'wbgetentities',
+			} )
+				.then( ( response: any ) => {
+					if ( !( 'entities' in response ) ) {
+						reject( new TechnicalProblem( 'wbgetentities result not well formed.' ) );
+					}
+
+					if ( !( id in response.entities ) ) {
+						reject( new EntityNotFound( 'wbgetentities result does not contain relevant entity.' ) );
+					}
+
+					const entity = response.entities[ id ];
+
+					if ( 'missing' in entity ) {
+						reject( new EntityNotFound( 'Entity flagged missing in response.' ) );
+					}
+
+					resolve( entity );
+				} )
+				.catch( ( reason: string ) => {
+					reject( new TechnicalProblem( reason ) );
+				} );
+		} );
+	}
+
+	public getFingerprintableEntity( id: string ): Promise<FingerprintableEntity> {
+		return new Promise( ( resolve, reject ) => {
+			this.getEntity( id )
+				.then( ( entity: any ) => {
+					try {
+						resolve ( this.entityInitializer.newFromSerialization( entity ) );
+					} catch ( e ) {
+						reject( new TechnicalProblem( e.message ) );
+					}
+				} )
+				.catch( ( reason ) => {
+					reject( reason );
+				} );
+		} );
+	}
+}

--- a/src/server/data-access/WikibaseRepo.ts
+++ b/src/server/data-access/WikibaseRepo.ts
@@ -1,0 +1,8 @@
+import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
+
+/**
+ * Rejects to TechnicalProblem or EntityNotFound errors in case of problems
+ */
+export default interface WikibaseRepo {
+	getFingerprintableEntity( id: string ): Promise<FingerprintableEntity>;
+}

--- a/src/server/data-access/error/EntityNotFound.ts
+++ b/src/server/data-access/error/EntityNotFound.ts
@@ -1,0 +1,1 @@
+export default class EntityNotFound extends Error {}

--- a/src/server/data-access/error/TechnicalProblem.ts
+++ b/src/server/data-access/error/TechnicalProblem.ts
@@ -1,0 +1,1 @@
+export default class TechnicalProblem extends Error {}

--- a/src/types/server/mwbot.d.ts
+++ b/src/types/server/mwbot.d.ts
@@ -1,0 +1,6 @@
+declare module 'mwbot' {
+	export default class mwbot {
+		constructor( config: object );
+		request( params: object ): Promise<object>;
+	}
+}

--- a/tests/unit/server/data-access/MwBotWikibaseRepo.spec.ts
+++ b/tests/unit/server/data-access/MwBotWikibaseRepo.spec.ts
@@ -1,0 +1,188 @@
+import EntityInitializer from '@/common/EntityInitializer';
+import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
+import MwBotWikibaseRepo from '@/server/data-access/MwBotWikibaseRepo';
+import EntityNotFound from '@/server/data-access/error/EntityNotFound';
+import TechnicalProblem from '@/server/data-access/error/TechnicalProblem';
+import mwbot from 'mwbot';
+
+function newMwBotWikibaseRepo( bot: any, initializer?: any ) {
+	return new MwBotWikibaseRepo(
+		bot,
+		initializer || {}
+	);
+}
+
+describe( 'MwBotWikibaseRepo', () => {
+
+	it( 'can be constructed with mwbot', () => {
+		expect( newMwBotWikibaseRepo( new mwbot( {} ) ) ).toBeInstanceOf( MwBotWikibaseRepo );
+	} );
+
+	describe( 'getFingerprintableEntity', () => {
+		it( 'creates a well-formed wbgetentities query', ( done ) => {
+			const entityId = 'Q42';
+			const bot = {
+				request: ( params: object ) => {
+					expect( params ).toEqual( {
+						ids: entityId,
+						action: 'wbgetentities',
+					} );
+
+					return Promise.reject( 'This test focuses on the request.' );
+				},
+			};
+
+			const repo = newMwBotWikibaseRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( () => {
+				done();
+			} );
+		} );
+
+		it( 'resolves to an Entity on success', ( done ) => {
+			const entityId = 'Q3';
+			const entity = {
+				pageid: 3,
+				ns: 120,
+				title: 'Item:Q3',
+				lastrevid: 1149,
+				modified: '2018-07-06T10:41:48Z',
+				type: 'item',
+				id: 'Q3',
+				labels: {
+					en: { language: 'en', value: 'potato' },
+					de: { language: 'de', value: 'Kartoffel' },
+				},
+				descriptions: {
+					en: { language: 'en', value: 'a root vegetable' },
+					de: { language: 'de', value: 'ein Wurzelgemüse' },
+				},
+				aliases: {
+					en: [
+						{ language: 'en', value: 'Spud' },
+					],
+				},
+				claims: {},
+				sitelinks: {},
+			};
+			const results = {
+				entities: {
+					Q3: entity,
+				},
+			};
+			const bot = {
+				request: ( params: object ) => {
+					return Promise.resolve( results );
+				},
+			};
+
+			const repo = newMwBotWikibaseRepo( bot, new EntityInitializer() );
+			repo.getFingerprintableEntity( entityId ).then( ( result: FingerprintableEntity ) => {
+				expect( result ).toBeInstanceOf( FingerprintableEntity );
+				expect( result.id ).toEqual( entity.id );
+				expect( result.labels ).toEqual( entity.labels );
+				expect( result.descriptions ).toEqual( entity.descriptions );
+				expect( result.aliases ).toEqual( entity.aliases );
+				done();
+			} );
+		} );
+
+		it( 'rejects on result missing entities key', ( done ) => {
+			const entityId = 'Q3';
+			const bot = {
+				request: ( params: object ) => {
+					return Promise.resolve( {} );
+				},
+			};
+			const repo = newMwBotWikibaseRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( TechnicalProblem );
+				expect( reason.message ).toEqual( 'wbgetentities result not well formed.' );
+				done();
+			} );
+		} );
+
+		it( 'rejects on result missing relevant entity in entities', ( done ) => {
+			// this maybe is not really a thing as wbgetentities returns the entity with a 'missing' key
+			const entityId = 'Q3';
+			const bot = {
+				request: ( params: object ) => {
+					return Promise.resolve( {
+						entities: {
+							Q4: {
+								irrelevant: 'value',
+							},
+						},
+					} );
+				},
+			};
+			const repo = newMwBotWikibaseRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( EntityNotFound );
+				expect( reason.message ).toEqual( 'wbgetentities result does not contain relevant entity.' );
+				done();
+			} );
+		} );
+
+		it( 'rejects on result indicating relevant entity as missing in entities', ( done ) => {
+			const entityId = 'Q3';
+			const bot = {
+				request: ( params: object ) => {
+					return Promise.resolve( {
+						entities: {
+							Q3: {
+								missing: '',
+							},
+						},
+					} );
+				},
+			};
+			const repo = newMwBotWikibaseRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( EntityNotFound );
+				expect( reason.message ).toEqual( 'Entity flagged missing in response.' );
+				done();
+			} );
+		} );
+
+		it( 'rejects stating the reason in case of API problems', ( done ) => {
+			const entityId = 'Q3';
+			const bot = {
+				request: ( params: object ) => {
+					return Promise.reject( new Error( 'invalidjson: No valid JSON response' ) );
+				},
+			};
+			const repo = newMwBotWikibaseRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( TechnicalProblem );
+				expect( reason.message ).toEqual( 'Error: invalidjson: No valid JSON response' );
+				done();
+			} );
+		} );
+
+		it( 'rejects stating the technical reason in case of entity initialization problem', ( done ) => {
+			const entityId = 'Q3';
+			const bot = {
+				request: ( params: object ) => {
+					return Promise.resolve( {
+						entities: {
+							Q3: {
+								id: 'Q3',
+							},
+						},
+					} );
+				},
+			};
+			const initializer = {
+				newFromSerialization: () => {
+					throw new Error( 'initializer sad' );
+				}
+			};
+			const repo = newMwBotWikibaseRepo( bot, initializer );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( TechnicalProblem );
+				expect( reason.message ).toEqual( 'initializer sad' );
+				done();
+			} );
+		} );
+	} );
+} );

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -32,7 +32,6 @@
 	  "tests/**/*.tsx"
   ],
   "exclude": [
-	  "node_modules",
-	  "src/types/**/*"
+    "node_modules"
   ]
 }

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -22,7 +22,7 @@
   },
   "exclude": [
 	  "node_modules",
-	  "src/types/**/*",
+	  "src/types/client/**/*",
 	  "src/mock-data/**/*",
 	  "src/mockup-entry.ts",
 	  "src/client/**/*",


### PR DESCRIPTION
Done through mwbot.
This makes our tests (ts-jest) use the tsconfig.all.json until we get to
re-organize the test folder to be able to test client-only and server-only (and possibly mixed) individually.
This is to ensure the typeRoots defined (for server) are not made obsolete by being excluded thereafter.

Bug: T207467