### PR TITLE
custom errors: ensure correct prototype

### DIFF
--- a/src/server/route-handler/termbox/error/EntityNotFound.ts
+++ b/src/server/route-handler/termbox/error/EntityNotFound.ts
@@ -1,6 +1,1 @@
-export default class EntityNotFound extends Error {
-	constructor( m: string ) {
-		super( m );
-		Object.setPrototypeOf( this, EntityNotFound.prototype );
-	}
-}
+export default class EntityNotFound extends Error {}

--- a/src/server/route-handler/termbox/error/InvalidRequest.ts
+++ b/src/server/route-handler/termbox/error/InvalidRequest.ts
@@ -1,6 +1,1 @@
-export default class InvalidRequest extends Error {
-	constructor( m: string ) {
-		super( m );
-		Object.setPrototypeOf( this, InvalidRequest.prototype );
-	}
-}
+export default class InvalidRequest extends Error {}

--- a/src/server/route-handler/termbox/error/TechnicalProblem.ts
+++ b/src/server/route-handler/termbox/error/TechnicalProblem.ts
@@ -1,6 +1,1 @@
-export default class TechnicalProblem extends Error {
-	constructor( m: string ) {
-		super( m );
-		Object.setPrototypeOf( this, TechnicalProblem.prototype );
-	}
-}
+export default class TechnicalProblem extends Error {}

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "outDir": "serverBuild",
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs",
     "sourceMap": true,
     "typeRoots": [
@@ -17,7 +17,6 @@
 		"express"
     ],
     "lib": [
-		"es5",
 		"esnext"
     ]
   },


### PR DESCRIPTION
Lack of features expected from the server side (https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work)
led us to discover that the target was actually set to ES5.
This obsoletes manual prototype setting.