### PR TITLE
TermboxHandler: dynamically create TermboxRequest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15544,6 +15544,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validate.js": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.12.0.tgz",
+      "integrity": "sha512-/x2RJSvbqEyxKj0RPN4xaRquK+EggjeVXiDDEyrJzsJogjtiZ9ov7lj/svVb4DM5Q5braQF4cooAryQbUwOxlA=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express": "^4.16.4",
     "module-alias": "^2.1.0",
     "mwbot": "^1.0.10",
+    "validate.js": "^0.12.0",
     "vue": "^2.5.17",
     "vue-class-component": "^6.0.0",
     "vue-property-decorator": "^7.0.0",
@@ -26,10 +27,10 @@
     "vuex": "^3.0.1"
   },
   "devDependencies": {
-    "@types/node": "^10.12.6",
     "@types/dotenv": "^4.0.3",
     "@types/express": "^4.16.0",
     "@types/jest": "^23.1.4",
+    "@types/node": "^10.12.6",
     "@types/supertest": "^2.0.6",
     "@vue/cli-plugin-babel": "^3.0.5",
     "@vue/cli-plugin-typescript": "^3.0.5",

--- a/src/server/route-handler/termbox/QueryValidator.ts
+++ b/src/server/route-handler/termbox/QueryValidator.ts
@@ -1,0 +1,46 @@
+import validate from 'validate.js';
+
+export default class QueryValidator {
+	private errors = [];
+
+	private CONSTRAINTS = {
+		language: {
+			presence: true,
+			format: {
+				pattern: /^[a-z]{2}[a-z-]*$/i,
+				message: ( value: any ) => {
+					return validate.format( '^"%{value}" is not a valid language code', {
+						value,
+					} );
+				},
+			},
+		},
+		entity: {
+			presence: true,
+			format: {
+				pattern: /^(Q|P)[1-9]\d{0,9}$/,
+				message: ( value: any ) => {
+					return validate.format( '^"%{value}" is not a valid entity id', {
+						value,
+					} );
+				},
+			},
+		},
+	};
+
+	public getErrors(): object[] {
+		return this.errors;
+	}
+
+	public validate( query: object ): boolean {
+		const result = validate.validate( query, this.CONSTRAINTS );
+
+		if ( result === undefined ) {
+			this.errors = [];
+			return true;
+		}
+
+		this.errors = result;
+		return false;
+	}
+}

--- a/src/server/route-handler/termbox/TermboxHandler.ts
+++ b/src/server/route-handler/termbox/TermboxHandler.ts
@@ -1,0 +1,53 @@
+import TermboxRequest from '@/common/TermboxRequest';
+import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
+import WikibaseRepo from '@/server/data-access/WikibaseRepo';
+import ApiEntityNotFound from '@/server/data-access/error/EntityNotFound';
+import EntityNotFound from './error/EntityNotFound';
+import InvalidRequest from './error/InvalidRequest';
+import TechnicalProblem from './error/TechnicalProblem';
+import QueryValidator from './QueryValidator';
+
+export default class TermboxHandler {
+
+	private repo: WikibaseRepo;
+	private queryValidator: QueryValidator;
+
+	constructor( queryValidator: QueryValidator, repo: WikibaseRepo ) {
+		this.queryValidator = queryValidator;
+		this.repo = repo;
+	}
+
+	public createTermboxRequest( query: any ): Promise<TermboxRequest> {
+		return new Promise( ( resolve, reject ) => {
+			if ( !this.queryValidator.validate( query ) ) {
+				reject(
+					new InvalidRequest(
+						'Request errors: ' + JSON.stringify( this.queryValidator.getErrors() ),
+					),
+				);
+				return;
+			}
+
+			const language = query.language;
+			const entityId = query.entity;
+
+			this.repo.getFingerprintableEntity( entityId )
+				.then( ( entity: FingerprintableEntity ) => {
+					resolve(
+						new TermboxRequest(
+							language,
+							entity,
+						),
+					);
+				} )
+				.catch( ( reason: Error ) => {
+					if ( reason instanceof ApiEntityNotFound ) {
+						reject( new EntityNotFound( reason.message ) );
+					} else {
+						reject( new TechnicalProblem( reason.message ) );
+					}
+				} );
+		} );
+	}
+
+}

--- a/src/server/route-handler/termbox/error/EntityNotFound.ts
+++ b/src/server/route-handler/termbox/error/EntityNotFound.ts
@@ -1,0 +1,6 @@
+export default class EntityNotFound extends Error {
+	constructor( m: string ) {
+		super( m );
+		Object.setPrototypeOf( this, EntityNotFound.prototype );
+	}
+}

--- a/src/server/route-handler/termbox/error/InvalidRequest.ts
+++ b/src/server/route-handler/termbox/error/InvalidRequest.ts
@@ -1,0 +1,6 @@
+export default class InvalidRequest extends Error {
+	constructor( m: string ) {
+		super( m );
+		Object.setPrototypeOf( this, InvalidRequest.prototype );
+	}
+}

--- a/src/server/route-handler/termbox/error/TechnicalProblem.ts
+++ b/src/server/route-handler/termbox/error/TechnicalProblem.ts
@@ -1,0 +1,6 @@
+export default class TechnicalProblem extends Error {
+	constructor( m: string ) {
+		super( m );
+		Object.setPrototypeOf( this, TechnicalProblem.prototype );
+	}
+}

--- a/tests/unit/server/route-handler/termbox/QueryValidator.spec.ts
+++ b/tests/unit/server/route-handler/termbox/QueryValidator.spec.ts
@@ -1,0 +1,39 @@
+import QueryValidator from '@/server/route-handler/termbox/QueryValidator';
+
+describe( 'QueryValidator', () => {
+	describe( 'validate', () => {
+		test.each( [
+			[ { entity: 'Q3' } ], // language missing
+			[ { language: 'de' } ], // entity missing
+			[ { entity: '', language: '' } ], // empty strings
+			[ { entity: '  ', language: '      ' } ], // evil strings
+			[ { entity: [ 'off', 'type' ], language: 'de' } ], // off-type value
+			[ { entity: 'randomstring', language: 'de' } ], // random entity
+			[ { entity: 'Q0', language: 'de' } ], // crafted entity
+		] )(
+			'rejects invalid request #%# (%o)',
+			( query: object ) => {
+				const queryValidator = new QueryValidator();
+				expect( queryValidator.validate( query ) ).toBe( false );
+				expect( queryValidator.getErrors() ).not.toEqual( [] );
+			},
+		);
+
+		test.each( [
+			[ { entity: 'Q2', language: 'de' } ],
+			[ { entity: 'P1', language: 'en' } ],
+			[ { entity: 'Q45121097', language: 'ru' } ],
+			[ { entity: 'P999', language: 'zh' } ],
+			[ { entity: 'Q4711', language: 'crh-Cyrl' } ],
+			[ { entity: 'P8888', language: 'zh-hans-sg' } ],
+			[ { entity: 'P999', language: 'zh', strayvalue: 'ignored' } ],
+		] )(
+			'accepts valid request #%# (%o)',
+			( query: object ) => {
+				const queryValidator = new QueryValidator();
+				expect( queryValidator.validate( query ) ).toBe( true );
+				expect( queryValidator.getErrors() ).toEqual( [] );
+			},
+		);
+	} );
+} );

--- a/tests/unit/server/route-handler/termbox/TermboxHandler.spec.ts
+++ b/tests/unit/server/route-handler/termbox/TermboxHandler.spec.ts
@@ -1,0 +1,101 @@
+import TermboxHandler from '@/server/route-handler/termbox/TermboxHandler';
+import mockQ64 from '@/mock-data/data/Q64_data.json';
+import TermboxRequest from '@/common/TermboxRequest';
+import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
+import InvalidRequest from '@/server/route-handler/termbox/error/InvalidRequest';
+import RepoTechnicalProblem from '@/server/data-access/error/TechnicalProblem';
+import RepoEntityNotFound from '@/server/data-access/error/EntityNotFound';
+import EntityNotFound from '@/server/route-handler/termbox/error/EntityNotFound';
+import TechnicalProblem from '@/server/route-handler/termbox/error/TechnicalProblem';
+import EntityInitializer from '@/common/EntityInitializer';
+
+function newTermboxHandler( queryValidator: any, repo: any ) {
+	return new TermboxHandler( queryValidator, repo );
+}
+
+describe( 'TermboxHandler', () => {
+	describe( 'createTermboxRequest', () => {
+		it( 'resolves to TermboxRequest on valid request', ( done ) => {
+			const entity = 'Q64';
+			const language = 'de';
+			const queryValidator = {
+				validate: () => true,
+			};
+			const repo = {
+				getFingerprintableEntity: ( id: string ) => {
+					return Promise.resolve(
+						( new EntityInitializer() ).newFromSerialization( mockQ64 ),
+					);
+				},
+			};
+
+			const routeHandler = newTermboxHandler( queryValidator, repo );
+			routeHandler.createTermboxRequest( { entity, language } )
+				.then( ( termboxRequest: TermboxRequest ) => {
+					expect( termboxRequest ).toBeInstanceOf( TermboxRequest );
+					expect( termboxRequest.language ).toEqual( language );
+					expect( termboxRequest.entity ).toBeInstanceOf( FingerprintableEntity );
+					expect( termboxRequest.entity.id ).toEqual( entity );
+					done();
+				} );
+		} );
+
+		it( 'rejects when failing to validate request', ( done ) => {
+			const request = { entity: '', language: '' };
+			const queryValidator = {
+				validate: () => false,
+				getErrors: () => [ { entity: 'bad' }, { language: 'worse' } ],
+			};
+			const routeHandler = newTermboxHandler( queryValidator, {} );
+
+			routeHandler.createTermboxRequest( request )
+				.catch( ( reason: Error ) => {
+					expect( reason ).toBeInstanceOf( InvalidRequest );
+					done();
+				} );
+		} );
+
+		it( 'rejects when failing to complete repo request', ( done ) => {
+			const entity = 'Q3';
+			const language = 'de';
+			const queryValidator = {
+				validate: () => true,
+			};
+			const repo = {
+				getFingerprintableEntity: ( entityId: string ) => {
+					return Promise.reject( new RepoTechnicalProblem( 'some technical repo problem' ) );
+				},
+			};
+
+			const routeHandler = newTermboxHandler( queryValidator, repo );
+			routeHandler.createTermboxRequest( { entity, language } )
+				.catch( ( reason: Error ) => {
+					expect( reason ).toBeInstanceOf( TechnicalProblem );
+					expect( reason.message ).toEqual( 'some technical repo problem' );
+					done();
+				} );
+		} );
+
+		it( 'rejects when failing to find entity in repo', ( done ) => {
+			const entity = 'Q3';
+			const language = 'de';
+			const queryValidator = {
+				validate: () => true,
+			};
+			const repo = {
+				getFingerprintableEntity: ( entityId: string ) => {
+					return Promise.reject( new RepoEntityNotFound( 'Entity flagged missing in response.' ) );
+				},
+			};
+
+			const routeHandler = newTermboxHandler( queryValidator, repo );
+			routeHandler.createTermboxRequest( { entity, language } )
+				.catch( ( reason: Error ) => {
+					expect( reason ).toBeInstanceOf( EntityNotFound );
+					expect( reason.message ).toEqual( 'Entity flagged missing in response.' );
+					done();
+				} );
+		} );
+
+	} );
+} );


### PR DESCRIPTION
Ability to derive the TermboxRequest from the HTTP request (query)

Consider `QueryValidator` the MVP of what can be done to make sure only sane inputs reach the next layer.

Bug: T207467