### PR TITLE
linting: let CI fail if there are warnings

### DIFF
--- a/src/server/data-access/MwBotWikibaseRepo.ts
+++ b/src/server/data-access/MwBotWikibaseRepo.ts
@@ -14,6 +14,22 @@ export default class MwBotWikibaseRepo implements WikibaseRepo {
 		this.entityInitializer = entityInitializer;
 	}
 
+	public getFingerprintableEntity( id: string ): Promise<FingerprintableEntity> {
+		return new Promise( ( resolve, reject ) => {
+			this.getEntity( id )
+				.then( ( entity: any ) => {
+					try {
+						resolve ( this.entityInitializer.newFromSerialization( entity ) );
+					} catch ( e ) {
+						reject( new TechnicalProblem( e.message ) );
+					}
+				} )
+				.catch( ( reason ) => {
+					reject( reason );
+				} );
+		} );
+	}
+
 	private getEntity( id: string ): Promise<any> {
 		return new Promise( ( resolve, reject ) => {
 			this.bot.request( {
@@ -39,22 +55,6 @@ export default class MwBotWikibaseRepo implements WikibaseRepo {
 				} )
 				.catch( ( reason: string ) => {
 					reject( new TechnicalProblem( reason ) );
-				} );
-		} );
-	}
-
-	public getFingerprintableEntity( id: string ): Promise<FingerprintableEntity> {
-		return new Promise( ( resolve, reject ) => {
-			this.getEntity( id )
-				.then( ( entity: any ) => {
-					try {
-						resolve ( this.entityInitializer.newFromSerialization( entity ) );
-					} catch ( e ) {
-						reject( new TechnicalProblem( e.message ) );
-					}
-				} )
-				.catch( ( reason ) => {
-					reject( reason );
 				} );
 		} );
 	}

--- a/tests/unit/server/data-access/MwBotWikibaseRepo.spec.ts
+++ b/tests/unit/server/data-access/MwBotWikibaseRepo.spec.ts
@@ -8,7 +8,7 @@ import mwbot from 'mwbot';
 function newMwBotWikibaseRepo( bot: any, initializer?: any ) {
 	return new MwBotWikibaseRepo(
 		bot,
-		initializer || {}
+		initializer || {},
 	);
 }
 
@@ -175,7 +175,7 @@ describe( 'MwBotWikibaseRepo', () => {
 			const initializer = {
 				newFromSerialization: () => {
 					throw new Error( 'initializer sad' );
-				}
+				},
 			};
 			const repo = newMwBotWikibaseRepo( bot, initializer );
 			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "defaultSeverity": "warning",
+  "defaultSeverity": "error",
   "extends": [
     "tslint:recommended",
     "./tslint-wikimedia-eslint-rules-port.json"


### PR DESCRIPTION
Ensure that CI is able to pick up liniting violations until tslint matures
further: palantir/tslint#2604
This makes the output look slightly different but it contains the same
information.

Also cleans up some warnings that slipped through CI before.