### PR TITLE
Configuration code style

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  presets: [
-    '@vue/app'
-  ]
-}
+	presets: [
+		'@vue/app',
+	],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,31 +1,31 @@
 module.exports = {
-  globals: {
-    'ts-jest': {
-      tsConfigFile: './tsconfig.all.json',
-    },
-  },
-  moduleFileExtensions: [
-    'js',
-    'jsx',
-    'json',
-    'vue',
-    'ts',
-    'tsx'
-  ],
-  transform: {
-    '^.+\\.vue$': 'vue-jest',
-    '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
-    '^.+\\.tsx?$': 'ts-jest'
-  },
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1'
-  },
-  setupTestFrameworkScriptFile: '<rootDir>/tests/config/setup.ts',
-  snapshotSerializers: [
-    'jest-serializer-vue'
-  ],
-  testMatch: [
-    '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)'
-  ],
-  testURL: 'http://localhost/'
+	globals: {
+		'ts-jest': {
+			tsConfigFile: './tsconfig.all.json',
+		},
+	},
+	moduleFileExtensions: [
+		'js',
+		'jsx',
+		'json',
+		'vue',
+		'ts',
+		'tsx',
+	],
+	transform: {
+		'^.+\\.vue$': 'vue-jest',
+		'.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
+		'^.+\\.tsx?$': 'ts-jest',
+	},
+	moduleNameMapper: {
+		'^@/(.*)$': '<rootDir>/src/$1',
+	},
+	setupTestFrameworkScriptFile: '<rootDir>/tests/config/setup.ts',
+	snapshotSerializers: [
+		'jest-serializer-vue',
+	],
+	testMatch: [
+		'**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)',
+	],
+	testURL: 'http://localhost/',
 };

--- a/jsduck.json
+++ b/jsduck.json
@@ -1,10 +1,10 @@
 {
-	"--title": "Wikibase Termbox - Documentation",
-	"--output": "docs",
-	"--processes": "0",
-	"--warnings-exit-nonzero": true,
-	"--builtin-classes": true,
-	"--warnings": ["-all"],
-	"--": [
-	]
+  "--title": "Wikibase Termbox - Documentation",
+  "--output": "docs",
+  "--processes": "0",
+  "--warnings-exit-nonzero": true,
+  "--builtin-classes": true,
+  "--warnings": ["-all"],
+  "--": [
+  ]
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: {
-    autoprefixer: {}
-  }
-}
+	plugins: {
+		autoprefixer: {},
+	},
+};

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -5,15 +5,15 @@
     "module": "esnext",
     "sourceMap": true,
     "typeRoots": [
-		"./src/types",
-		"./src/types/client",
-		"./src/types/server",
-		"./node_modules/@types"
+      "./src/types",
+      "./src/types/client",
+      "./src/types/server",
+      "./node_modules/@types"
     ],
     "types": [
-		"webpack-env",
-		"jest",
-		"node"
+      "webpack-env",
+      "jest",
+      "node"
     ],
     "lib": [
       "esnext",
@@ -25,13 +25,13 @@
     "allowJs": true
   },
   "include": [
-	  "./*.js",
-	  "src/**/*.ts",
-	  "src/**/*.tsx",
-	  "src/**/*.vue",
-	  "tests/**/*.ts",
-	  "tests/**/*.ts",
-	  "tests/**/*.tsx"
+    "./*.js",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "tests/**/*.ts",
+    "tests/**/*.ts",
+    "tests/**/*.tsx"
   ],
   "exclude": [
     "node_modules"

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -21,9 +21,11 @@
       "dom",
       "dom.iterable",
       "scripthost"
-    ]
+    ],
+    "allowJs": true
   },
   "include": [
+	  "./*.js",
 	  "src/**/*.ts",
 	  "src/**/*.tsx",
 	  "src/**/*.vue",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,14 +5,14 @@
     "module": "esnext",
     "sourceMap": true,
     "typeRoots": [
-		"./src/types",
-		"./src/types/client",
-		"./node_modules/@types"
+      "./src/types",
+      "./src/types/client",
+      "./node_modules/@types"
     ],
     "types": [
-		"webpack-env",
-		"jest",
-		"node"
+      "webpack-env",
+      "jest",
+      "node"
     ],
     "lib": [
       "esnext",
@@ -22,11 +22,11 @@
     ]
   },
   "exclude": [
-	  "node_modules",
-	  "src/types/**/*",
-	  "src/mock-data/**/*",
-	  "src/mockup-entry.ts",
-	  "src/server/**/*",
-	  "src/server-entry.ts"
+    "node_modules",
+    "src/types/**/*",
+    "src/mock-data/**/*",
+    "src/mockup-entry.ts",
+    "src/server/**/*",
+    "src/server-entry.ts"
   ]
 }

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -6,27 +6,27 @@
     "module": "commonjs",
     "sourceMap": true,
     "typeRoots": [
-		"./src/types",
-		"./src/types/server",
-		"./node_modules/@types"
+      "./src/types",
+      "./src/types/server",
+      "./node_modules/@types"
     ],
     "types": [
-		"webpack-env",
-		"jest",
-		"node",
-		"express"
+      "webpack-env",
+      "jest",
+      "node",
+      "express"
     ],
     "lib": [
-		"es5",
-		"esnext"
+      "es5",
+      "esnext"
     ]
   },
   "exclude": [
-	  "node_modules",
-	  "src/types/client/**/*",
-	  "src/mock-data/**/*",
-	  "src/mockup-entry.ts",
-	  "src/client/**/*",
-	  "src/client-entry.ts"
-	]
+    "node_modules",
+    "src/types/client/**/*",
+    "src/mock-data/**/*",
+    "src/mockup-entry.ts",
+    "src/client/**/*",
+    "src/client-entry.ts"
+  ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -15,5 +15,10 @@
     "interface-name": false,
     "ordered-imports": false,
     "object-literal-sort-keys": false
+  },
+  "jsRules": {
+    "quotemark": [ true, "single" ],
+    "indent": [ true, "tabs" ],
+    "object-literal-sort-keys": false
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,53 +1,53 @@
-const VueSSRServerPlugin = require('vue-server-renderer/server-plugin')
-const VueSSRClientPlugin = require('vue-server-renderer/client-plugin')
+const VueSSRServerPlugin = require( 'vue-server-renderer/server-plugin' );
+const VueSSRClientPlugin = require( 'vue-server-renderer/client-plugin' );
 
-const TARGET_NODE = process.env.WEBPACK_TARGET === 'node'
-const DEV_MODE = process.env.WEBPACK_TARGET === 'dev'
-const filePrefix = 'wikibase.termbox.'
+const TARGET_NODE = process.env.WEBPACK_TARGET === 'node';
+const DEV_MODE = process.env.WEBPACK_TARGET === 'dev';
+const filePrefix = 'wikibase.termbox.';
 
 const target = TARGET_NODE
-  ? 'server'
-  : 'client'
+	? 'server'
+	: 'client';
 
 module.exports = {
-  outputDir: TARGET_NODE ? 'serverDist' : 'dist',
-  configureWebpack: () => ({
-	entry: DEV_MODE ? [ './src/mockup-entry.ts', `./src/${target}-entry.ts` ] : `./src/${target}-entry.ts`,
-    target: TARGET_NODE ? 'node' : 'web',
-    node: TARGET_NODE ? undefined : false,
-    plugins: [
-      TARGET_NODE
-        ? new VueSSRServerPlugin()
-        : new VueSSRClientPlugin()
-    ],
-    output: {
-      libraryTarget: TARGET_NODE
-        ? 'commonjs2'
-        : undefined,
-      filename: `${filePrefix}[name].js`
-    },
-    optimization: {
-      splitChunks: undefined
-    }
-  }),
-  chainWebpack: config => {
-    config.optimization.delete('splitChunks')
+	outputDir: TARGET_NODE ? 'serverDist' : 'dist',
+	configureWebpack: () => ( {
+		entry: DEV_MODE ? [ './src/mockup-entry.ts', `./src/${target}-entry.ts` ] : `./src/${target}-entry.ts`,
+		target: TARGET_NODE ? 'node' : 'web',
+		node: TARGET_NODE ? undefined : false,
+		plugins: [
+			TARGET_NODE
+				? new VueSSRServerPlugin()
+				: new VueSSRClientPlugin(),
+		],
+		output: {
+			libraryTarget: TARGET_NODE
+				? 'commonjs2'
+				: undefined,
+			filename: `${filePrefix}[name].js`,
+		},
+		optimization: {
+			splitChunks: undefined,
+		},
+	} ),
+	chainWebpack: config => {
+		config.optimization.delete( 'splitChunks' );
 
-    if ( process.env.NODE_ENV === 'production' ) {
-      config.plugin('extract-css')
-        .tap(([options, ...args]) => [
-            Object.assign({}, options, { filename: `${filePrefix}[name].css` }),
-            ...args
-        ])
-    }
+		if ( process.env.NODE_ENV === 'production' ) {
+			config.plugin( 'extract-css' )
+				.tap( ( [ options, ...args ] ) => [
+					Object.assign( {}, options, { filename: `${filePrefix}[name].css` } ),
+					...args,
+				] );
+		}
 
-    config.module
-      .rule('vue')
-      .use('vue-loader')
-      .tap(options =>
-        Object.assign(options, {
-          optimizeSSR: false
-        })
-      )
-  }
-}
+		config.module
+			.rule( 'vue' )
+			.use( 'vue-loader' )
+			.tap( options =>
+				Object.assign( options, {
+					optimizeSSR: false,
+				} ),
+			);
+	},
+};


### PR DESCRIPTION
Let tslint check our JS (configuration) files in the project root, too.
With the release of palantir/tslint#3641 (I subscribed) the manual [prototypical] re-specification of `jsRules` will hopefully be obsolte soon.

Consistently indent JSON files. This goes against the tab indentation we
do for program files but allows for configuration files modified by
programs (e.g. npm using JSON.stringify() for package.json) to stay
consistent in the long run.