### PR TITLE
WikibaseRepo: fix ill-placed doc

### DIFF
--- a/src/server/data-access/WikibaseRepo.ts
+++ b/src/server/data-access/WikibaseRepo.ts
@@ -1,8 +1,8 @@
 import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
 
-/**
- * Rejects to TechnicalProblem or EntityNotFound errors in case of problems
- */
 export default interface WikibaseRepo {
+	/**
+	 * Rejects to TechnicalProblem or EntityNotFound errors in case of problems
+	 */
 	getFingerprintableEntity( id: string ): Promise<FingerprintableEntity>;
 }


### PR DESCRIPTION
Method documentation was placed on class level by accident.