### PR TITLE
migrate jest config to newer version

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,16 @@
 module.exports = {
 	globals: {
 		'ts-jest': {
-			tsConfigFile: './tsconfig.all.json',
+			tsConfig: './tsconfig.all.json',
 		},
 	},
 	moduleFileExtensions: [
 		'js',
-		'jsx',
 		'json',
-		'vue',
+		'jsx',
 		'ts',
 		'tsx',
+		'vue',
 	],
 	transform: {
 		'^.+\\.vue$': 'vue-jest',
@@ -28,4 +28,5 @@ module.exports = {
 		'**/tests/(unit|edge-to-edge)/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)',
 	],
 	testURL: 'http://localhost/',
+	preset: 'ts-jest',
 };


### PR DESCRIPTION
Warnings became annoying. Effective change is `tsConfigFile` to
`tsConfig`.
Warnings were
ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.tsConfigFile" is deprecated, use "[jest-config].globals.ts-jest.tsConfig" instead.
ts-jest[backports] (WARN) Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
Did run
docker-compose run --rm node npx ts-jest config:migrate jest.config.js