### PR TITLE
InvalidRawEntityException: rm unused file

### DIFF
--- a/src/store/entity/exceptions/InvalidRawEntityException.ts
+++ b/src/store/entity/exceptions/InvalidRawEntityException.ts
@@ -1,7 +1,0 @@
-import ParameterException from '@/common/exceptions/ParameterException';
-
-export default class InvalidEntityException extends ParameterException {
-	constructor( message?: string ) {
-		super( message );
-	}
-}


### PR DESCRIPTION
Remove unused file containing an exception class definition not matching
its file name.