### PR TITLE
EntityRepository.spec: omit mock data use

### DIFF
--- a/tests/unit/client/data-access/EntityRepository.spec.ts
+++ b/tests/unit/client/data-access/EntityRepository.spec.ts
@@ -1,6 +1,5 @@
 import EntityRepository from '@/client/data-access/EntityRepository';
 import MwWindow from '@/client/MwWindow';
-import MwConfig from '@/mock-data/MwConfig';
 import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
 import ImmediatelyInvokingEntityLoadedHookHandler from '@/mock-data/ImmediatelyInvokingEntityLoadedHookHandler';
 
@@ -14,11 +13,14 @@ describe( 'EntityRepository', () => {
 			descriptions: { en: { language: 'en', value: 'root vegetable' } },
 			aliases: { en: [ { language: 'en', value: 'patata' } ] },
 		};
+		const configGet = jest.fn();
 		( window as MwWindow ).mw = {
 			hook() {
 				return new ImmediatelyInvokingEntityLoadedHookHandler( entityReturnedFromHook );
 			},
-			config: new MwConfig(),
+			config: {
+				get: configGet,
+			},
 		};
 
 		return entityRepository.getFingerprintableEntity( 'Q123' ).then( ( entity: FingerprintableEntity ) => {
@@ -28,6 +30,8 @@ describe( 'EntityRepository', () => {
 			expect( entity.labels ).toBe( entityReturnedFromHook.labels );
 			expect( entity.descriptions ).toBe( entityReturnedFromHook.descriptions );
 			expect( entity.aliases ).toBe( entityReturnedFromHook.aliases );
+
+			expect( configGet ).not.toBeCalled();
 		} );
 	} );
 


### PR DESCRIPTION
Omit the confusing and unneeded use of mock-data/MwConfig, instead prove
that it is - despite being globally available - not accessed by
EntityRepository.