### PR TITLE
server: use constants for HTTP status codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7575,6 +7575,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.3.0.tgz",
+      "integrity": "sha1-nNDnE5F3PQZxtInUHLxQlKpBY7Y="
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "dotenv": "^6.1.0",
     "express": "^4.16.4",
+    "http-status-codes": "^1.3.0",
     "module-alias": "^2.1.0",
     "mwbot": "^1.0.10",
     "validate.js": "^0.12.0",

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -5,6 +5,7 @@ import TermboxHandler from './route-handler/termbox/TermboxHandler';
 import QueryValidator from './route-handler/termbox/QueryValidator';
 import InvalidRequest from './route-handler/termbox/error/InvalidRequest';
 import EntityNotFound from '@/common/data-access/error/EntityNotFound';
+import HttpStatus from 'http-status-codes';
 
 const app = express();
 const serverBundle = fs.readFileSync( './serverDist/vue-ssr-server-bundle.json' );
@@ -26,11 +27,11 @@ app.get( '/termbox', ( request, response ) => {
 		} )
 		.catch( ( err ) => {
 			if ( err instanceof InvalidRequest ) {
-				response.status( 400 ).send( 'Bad request' );
+				response.status( HttpStatus.BAD_REQUEST ).send( 'Bad request' );
 			} else if ( err.constructor.name === EntityNotFound.name ) { // how to instanceof?
-				response.status( 404 ).send( 'Entity not found' );
+				response.status( HttpStatus.NOT_FOUND ).send( 'Entity not found' );
 			} else {
-				response.status( 500 ).send( 'Technical problem ' + JSON.stringify( err ) );
+				response.status( HttpStatus.INTERNAL_SERVER_ERROR ).send( 'Technical problem ' + JSON.stringify( err ) );
 			}
 		} );
 } );


### PR DESCRIPTION
Use constants provided by
https://www.npmjs.com/package/http-status-codes instead of magic
strings.