### PR TITLE
reset-css: use sass import

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -36,6 +36,6 @@ export default class App extends Vue {
 
 <style lang="scss">
 .wikibase-entitytermsview {
-	@import 'reset-css';
+	@import '~reset-css/sass/_reset';
 }
 </style>


### PR DESCRIPTION
Avoid deprecated CSS import which caused a warning.
"Including .css files with @import is non-standard behaviour which
will be removed in future versions of LibSass.
Use a custom importer to maintain this behaviour. Check your
implementations documentation on how to create a custom importer."