### PR TITLE
blubber: build and test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+dist
+node_modules
+serverBuild
+serverDist

--- a/.pipeline/blubber.yaml
+++ b/.pipeline/blubber.yaml
@@ -1,0 +1,22 @@
+version: v3
+
+base: docker-registry.wikimedia.org/nodejs10-slim
+
+# can't live in /srv/service as currently node_modules outside of project root is not supported
+lives:
+  in: /opt/lib
+
+variants:
+  build:
+    base: docker-registry.wikimedia.org/nodejs10-devel
+    node:
+      requirements: [ package.json, package-lock.json ]
+  build-server:
+    includes: [ build ]
+    builder:
+      command: [ npm, run-script, build-server ]
+      requirements: [ "." ]
+  test:
+    # technically build-server is only needed for tests/edge-to-edge
+    includes: [ build-server ]
+    entrypoint: [ npm, test ]

--- a/README.md
+++ b/README.md
@@ -40,3 +40,18 @@ docker-compose run --rm node npm install
 ## Development
 * `docker-compose run --rm node npm run test` runs all tests
 * `docker-compose run --rm node npm run lint` for linting, `docker-compose run --rm node npm run fix` for fixing fixable lint errors
+
+## Blubber build
+
+This project can be build with [blubber](https://wikitech.wikimedia.org/wiki/Blubber), configuration is located in the `.pipeline` directory.
+
+Instructions above will gradually be migrated to use blubber.
+
+Beware, for the time being, blubber generated Dockerfiles conflict with the hand-crafted, earlier version.
+
+Running tests
+```
+blubber .pipeline/blubber.yaml test > Dockerfile
+docker build -t wmde/wikibase-termbox-test .
+docker run --rm wmde/wikibase-termbox-test
+```


### PR DESCRIPTION
Add basic blubber configuration, with variants
* build - effectively `npm install`
* build-server - equivalent to npm's 'build-server' script
* test - equivalent to npm's 'test' script

Certain folders will not be copied into images - they are derived and
supposed to be created inside.

See
https://wikitech.wikimedia.org/wiki/Blubber#Use
https://wikitech.wikimedia.org/wiki/Streamlined_Service_Delivery_Design#Testing/building_pipeline
https://github.com/wikimedia/mathoid/blob/master/.pipeline/blubber.yaml
https://gerrit.wikimedia.org/r/#/c/wikidata/query/gui/+/472649/6/.pipeline/blubber.yaml

Added a `blubber` [bash alias](https://github.com/wiese/dot-files/blob/master/.bash_aliases) to my list for convenience.

Bug: T211321