### PR TITLE
Disallow inferrable type declarations

### DIFF
--- a/src/store/entity/index.ts
+++ b/src/store/entity/index.ts
@@ -11,7 +11,7 @@ const state: Entity = {
 	aliases: {},
 };
 
-const namespaced: boolean = true;
+const namespaced = true;
 
 export const entity: Module<Entity, any> = {
 	namespaced,

--- a/src/store/entity/mutationTypes.ts
+++ b/src/store/entity/mutationTypes.ts
@@ -1,1 +1,1 @@
-export const ENTITY_INIT: string = 'initializeEntity';
+export const ENTITY_INIT = 'initializeEntity';

--- a/src/store/language/index.ts
+++ b/src/store/language/index.ts
@@ -9,7 +9,7 @@ const state: LanguageState = {
 	languages: {},
 };
 
-const namespaced: boolean = true;
+const namespaced = true;
 
 export const language: Module<LanguageState, any> = {
 	namespaced,

--- a/src/store/language/mutationTypes.ts
+++ b/src/store/language/mutationTypes.ts
@@ -1,2 +1,2 @@
-export const LANGUAGE_TRANSLATION_UPDATE: string = 'translationUpdate';
-export const LANGUAGE_UPDATE: string = 'languageUpdate';
+export const LANGUAGE_TRANSLATION_UPDATE = 'translationUpdate';
+export const LANGUAGE_UPDATE = 'languageUpdate';

--- a/src/store/namespaces.ts
+++ b/src/store/namespaces.ts
@@ -1,3 +1,3 @@
-export const NS_ENTITY: string = 'entity';
-export const NS_USER: string = 'user';
-export const NS_LANGUAGE: string = 'language';
+export const NS_ENTITY = 'entity';
+export const NS_USER = 'user';
+export const NS_LANGUAGE = 'language';

--- a/src/store/user/index.ts
+++ b/src/store/user/index.ts
@@ -8,7 +8,7 @@ const state: User = {
 	primaryLanguage: '',
 };
 
-const namespaced: boolean = true;
+const namespaced = true;
 
 export const user: Module<User, any> = {
 	namespaced,

--- a/src/store/user/mutationTypes.ts
+++ b/src/store/user/mutationTypes.ts
@@ -1,1 +1,1 @@
-export const LANGUAGE_INIT: string = 'initializeLanguage';
+export const LANGUAGE_INIT = 'initializeLanguage';

--- a/tests/unit/store/data/UserStores.ts
+++ b/tests/unit/store/data/UserStores.ts
@@ -2,7 +2,7 @@ import { Module } from 'vuex';
 import User from '@/store/user/User';
 import { getters } from '@/store/user/getters';
 
-const namespaced: boolean = false;
+const namespaced = false;
 
 let state: User = {
 	primaryLanguage: '',

--- a/tslint.json
+++ b/tslint.json
@@ -15,7 +15,8 @@
     "interface-name": false,
     "ordered-imports": false,
     "object-literal-sort-keys": false,
-    "import-spacing": false
+    "import-spacing": false,
+    "no-inferrable-types": true
   },
   "jsRules": {
     "quotemark": [ true, "single" ],


### PR DESCRIPTION
Unfortunately, this only works for variables and parameters (but not return types?), and only for number, string, or boolean. https://palantir.github.io/tslint/rules/no-inferrable-types/

I stumbled across this looking for something that can help us prevent unnecessary casting, which I saw in quite some places, but as far as I can tell there is no such thing.