### PR TITLE
tslib: ensure presence in prod installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15148,8 +15148,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
       "version": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mwbot": "^1.0.10",
     "rtl-detect": "^1.0.2",
     "ts-deferred": "^1.0.4",
+    "tslib": "^1.9.3",
     "validate.js": "^0.12.0",
     "vue": "^2.5.17",
     "vue-class-component": "^6.0.0",


### PR DESCRIPTION
We run typescript with the configuration `importHelpers: true`,
consequently the compiler will inject helper functions into the
generated output that are called at run-time. These helper functions
reside in the tslib library which consequently has to be installed.
So far it has only been installed as a 3rd party dependency of some of
our dev dependencies. Consequently running the server with only prod
dependencies installed, as we plan for production, failed.
See
https://blog.mariusschulz.com/2016/12/16/typescript-2-1-external-helpers-library
https://www.npmjs.com/package/tslib