### PR TITLE
Remove unnecessary type casts

### DIFF
--- a/src/client/data-access/UlsLanguageTranslationRepository.ts
+++ b/src/client/data-access/UlsLanguageTranslationRepository.ts
@@ -13,7 +13,7 @@ export default class UlsLanguageTranslationRepository implements LanguageTransla
 		return new Promise<LanguageTranslations>( ( resolve ) => {
 			resolve( {
 				[inLanguage]: this.getLanguagesNames(),
-			} as LanguageTranslations );
+			} );
 		} );
 	}
 

--- a/src/mockup-entry.ts
+++ b/src/mockup-entry.ts
@@ -13,7 +13,7 @@ import MwWindow from '@/client/mediawiki/MwWindow';
 
 class MockupWikibaseContentLanguages {
 	public getAllPairs(): StringTMap<string> {
-		return languageMap.default as StringTMap<string>;
+		return languageMap.default;
 	}
 }
 

--- a/src/server/data-access/ContentLanguagesLanguageRepo.ts
+++ b/src/server/data-access/ContentLanguagesLanguageRepo.ts
@@ -1,6 +1,5 @@
 import LanguageRepository from '@/common/data-access/LanguageRepository';
 import LanguageCollection from '@/datamodel/LanguageCollection';
-import Language from '@/datamodel/Language';
 import WikibaseContentLanguagesRepo, { WikibaseApiContentLanguages } from './WikibaseContentLanguagesRepo';
 import RtlDetectLib from 'rtl-detect';
 
@@ -22,7 +21,7 @@ export default class ContentLanguagesLanguageRepo implements LanguageRepository 
 						// * languages do not have directionality - scripts do
 						// * the configured wikibase instance may have more/different languages
 						directionality: RtlDetectLib.getLangDir( languageCode ),
-					} as Language;
+					};
 				} );
 
 				return languages;

--- a/tests/unit/client/data-access/UlsLanguageRepository.spec.ts
+++ b/tests/unit/client/data-access/UlsLanguageRepository.spec.ts
@@ -3,8 +3,8 @@ import { StringTMap } from '@/datamodel/LanguageTranslations';
 
 describe( 'UlsLanguageRepository', () => {
 	it( 'get WikibaseContentLanguages and uls to build a language collection', () => {
-		const langTranslation = { en: 'English', he: 'Hebrew', ar: 'Arabic', de: 'German' } as StringTMap<string>;
-		const langDirs = { en: 'ltr', he: 'rtl', ar: 'rtl', de: 'ltr' } as StringTMap<string>;
+		const langTranslation: StringTMap<string> = { en: 'English', he: 'Hebrew', ar: 'Arabic', de: 'German' };
+		const langDirs: StringTMap<string> = { en: 'ltr', he: 'rtl', ar: 'rtl', de: 'ltr' };
 		const translator = {
 			getAllPairs: () => langTranslation,
 		};

--- a/tests/unit/components/TermBox.spec.ts
+++ b/tests/unit/components/TermBox.spec.ts
@@ -11,7 +11,6 @@ import { ENTITY_INIT } from '@/store/entity/mutationTypes';
 import { LANGUAGE_INIT } from '@/store/user/mutationTypes';
 import { LANGUAGE_TRANSLATION_UPDATE } from '@/store/language/mutationTypes';
 import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
-import LanguageTranslations from '@/datamodel/LanguageTranslations';
 
 const localVue = createLocalVue();
 const langDe = 'Deutsch';
@@ -65,7 +64,7 @@ describe( 'TermBox.vue', () => {
 				de: 'German',
 				en: 'English',
 			},
-		} as LanguageTranslations,
+		},
 	);
 
 	it( 'renders the language label', () => {

--- a/tests/unit/server/data-access/ContentLanguagesLanguageRepo.spec.ts
+++ b/tests/unit/server/data-access/ContentLanguagesLanguageRepo.spec.ts
@@ -2,7 +2,6 @@ import LanguageCollection from '@/datamodel/LanguageCollection';
 import MwBotWikibaseContentLanguagesRepo from '@/server/data-access/MwBotWikibaseContentLanguagesRepo';
 import mwbot from 'mwbot';
 import ContentLanguagesLanguageRepo from '@/server/data-access/ContentLanguagesLanguageRepo';
-import { WikibaseApiContentLanguages } from '@/server/data-access/WikibaseContentLanguagesRepo';
 import RtlDetectLib from 'rtl-detect';
 
 function newWikibaseContentLanguagesRepository( contentLanguagesRepo: any ) {
@@ -30,7 +29,7 @@ describe( 'ContentLanguagesLanguageRepo', () => {
 					code: 'ar',
 					name: 'Arabic',
 				},
-			} as WikibaseApiContentLanguages );
+			} );
 			const contentLanguagesRepo = {
 				getContentLanguages,
 			};
@@ -47,7 +46,7 @@ describe( 'ContentLanguagesLanguageRepo', () => {
 						code: 'ar',
 						directionality: 'rtl',
 					},
-				} as LanguageCollection );
+				} );
 				done();
 			} );
 		} );
@@ -65,7 +64,7 @@ describe( 'ContentLanguagesLanguageRepo', () => {
 					code: 'ar',
 					name: 'Arabic',
 				},
-			} as WikibaseApiContentLanguages );
+			} );
 			const contentLanguagesRepo = {
 				getContentLanguages,
 			};

--- a/tests/unit/server/data-access/ContentLanguagesLanguageTranslationRepo.spec.ts
+++ b/tests/unit/server/data-access/ContentLanguagesLanguageTranslationRepo.spec.ts
@@ -45,7 +45,7 @@ describe( 'ContentLanguagesLanguageTranslationRepo', () => {
 						en: 'Englisch',
 						de: 'Deutsch',
 					},
-				} as LanguageTranslations );
+				} );
 				done();
 			} );
 		} );

--- a/tests/unit/store/entity/getters.spec.ts
+++ b/tests/unit/store/entity/getters.spec.ts
@@ -8,7 +8,7 @@ function newMinimalStore( fields: any ): Entity {
 		descriptions: {},
 		aliases: {},
 		...fields,
-	} as Entity;
+	};
 }
 
 describe( 'entity/Getters', () => {

--- a/tests/unit/store/entity/mutations.spec.ts
+++ b/tests/unit/store/entity/mutations.spec.ts
@@ -12,7 +12,7 @@ function newMinimalStore(): Entity {
 		labels: {},
 		descriptions: {},
 		aliases: {},
-	} as Entity;
+	};
 }
 
 describe( 'entity/mutations', () => {

--- a/tests/unit/store/language/actions.spec.ts
+++ b/tests/unit/store/language/actions.spec.ts
@@ -11,7 +11,7 @@ import LanguageCollection from '@/datamodel/LanguageCollection';
 describe( 'language/actions', () => {
 	describe( LANGUAGE_INIT, () => {
 		it( 'commits a fixed set of languages and returns a resolved promise', ( done ) => {
-			const languages = {
+			const languages: LanguageCollection = {
 				en: {
 					code: 'en',
 					directionality: 'ltr',
@@ -24,7 +24,7 @@ describe( 'language/actions', () => {
 					code: 'ar',
 					directionality: 'rtl',
 				},
-			} as LanguageCollection;
+			};
 			const getLanguagesMock = jest.fn();
 			getLanguagesMock.mockResolvedValue( languages );
 			factory.setLanguageRepository( {
@@ -49,12 +49,12 @@ describe( 'language/actions', () => {
 	describe( ENSURE_AVAILABLE_IN_LANGUAGE, () => {
 		it( `commits translations to ${LANGUAGE_TRANSLATION_UPDATE} on getLanguagesInLanguage lookup`, ( done ) => {
 			const inLanguage = 'de';
-			const translations = {
+			const translations: LanguageTranslations = {
 				de: {
 					de: 'Deutsch',
 					en: 'Englisch',
 				},
-			} as LanguageTranslations;
+			};
 			factory.setLanguageTranslationRepository( {
 				getLanguagesInLanguage: ( thisInLanguage: string ) => {
 					expect( thisInLanguage ).toBe( inLanguage );

--- a/tests/unit/store/language/getters.spec.ts
+++ b/tests/unit/store/language/getters.spec.ts
@@ -19,7 +19,7 @@ function newMinimalStore(): LanguageState {
 				en: 'English',
 			},
 		},
-	} as LanguageState;
+	};
 }
 
 describe( 'language/Getters', () => {

--- a/tests/unit/store/language/mutations.spec.ts
+++ b/tests/unit/store/language/mutations.spec.ts
@@ -11,14 +11,14 @@ function newMinimalStore(): LanguageState {
 	return {
 		translations: {},
 		languages: {},
-	} as LanguageState;
+	};
 }
 
 describe( 'language/mutations', () => {
 	describe( LANGUAGE_UPDATE, () => {
 		it( 'contains languages after initialization', () => {
 			const store = newMinimalStore();
-			const languages = {
+			const languages: LanguageCollection = {
 				de: {
 					code: 'de',
 					directionality: 'ltr',
@@ -27,7 +27,7 @@ describe( 'language/mutations', () => {
 					code: 'en',
 					directionality: 'ltr',
 				},
-			} as LanguageCollection;
+			};
 
 			mutations[ LANGUAGE_UPDATE ]( store, languages );
 
@@ -42,7 +42,7 @@ describe( 'language/mutations', () => {
 				directionality: 'ltr',
 			};
 			store.languages.de = originalDe;
-			const languages = {
+			const languages: LanguageCollection = {
 				en: {
 					code: 'en',
 					directionality: 'ltr',
@@ -51,7 +51,7 @@ describe( 'language/mutations', () => {
 					code: 'ar',
 					directionality: 'rtl',
 				},
-			} as LanguageCollection;
+			};
 
 			mutations[ LANGUAGE_UPDATE ]( store, languages );
 
@@ -81,7 +81,7 @@ describe( 'language/mutations', () => {
 
 		it( 'contains entity data after initialization', () => {
 			const store = newMinimalStore();
-			const translations = {
+			const translations: LanguageTranslations = {
 				de: {
 					de: 'Deutsch',
 					en: 'Englisch',
@@ -90,7 +90,7 @@ describe( 'language/mutations', () => {
 					de: 'German',
 					en: 'English',
 				},
-			} as LanguageTranslations;
+			};
 
 			mutations[ LANGUAGE_TRANSLATION_UPDATE ]( store, translations );
 


### PR DESCRIPTION
Explicit type hints are fine and can be helpful even if they are technically redundant, but unnecessary casts are confusing, because they give the impression that we're forcing an object into a type that it isn't.