### PR TITLE
app: let bundle renderer unpack the bundle

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import { resolve } from 'path';
 import express, { Request, Response } from 'express';
 import { createBundleRenderer } from 'vue-server-renderer';
 import TermboxHandler from './route-handler/termbox/TermboxHandler';
@@ -8,9 +8,8 @@ import HttpStatus from 'http-status-codes';
 import BundleBoundaryPassingException, { ErrorReason } from './exceptions/BundleBoundaryPassingException';
 
 const app = express();
-const serverBundle = fs.readFileSync( './serverDist/vue-ssr-server-bundle.json' );
 const renderer = createBundleRenderer(
-	JSON.parse( serverBundle.toString() ),
+	resolve( './serverDist/vue-ssr-server-bundle.json' ),
 	{ runInNewContext: false },
 );
 


### PR DESCRIPTION
When passed a file name, bundle renderer knows how to unpack the bundle.
Let it perform this action as it probably knows best - better than our
own code at least.
https://github.com/vuejs/vue/blob/52719ccab8fccffbdf497b96d3731dc86f04c1ce/src/server/bundle-renderer/create-bundle-renderer.js#L41