### PR TITLE
[WIP] server: implement a Special:EntityData EntityRepository

### DIFF
--- a/src/server-entry.ts
+++ b/src/server-entry.ts
@@ -1,6 +1,6 @@
 import buildApp from '@/common/buildApp';
 import { factory } from './common/TermboxFactory';
-import MwBotWikibaseFingerprintableEntityRepo from './server/data-access/MwBotWikibaseFingerprintableEntityRepo';
+import MwBotSpecialPageEntityRepo from './server/data-access/MwBotSpecialPageEntityRepo';
 import EntityInitializer from './common/EntityInitializer';
 import BundleBoundaryPassingException, { ErrorReason } from '@/server/exceptions/BundleBoundaryPassingException';
 import EntityNotFound from '@/common/data-access/error/EntityNotFound';
@@ -36,7 +36,7 @@ export default ( context: BundleRendererContext ) => {
 		),
 	);
 	factory.setEntityRepository(
-		new MwBotWikibaseFingerprintableEntityRepo(
+		new MwBotSpecialPageEntityRepo(
 			apiBot,
 			new EntityInitializer(),
 		),

--- a/src/server/data-access/MwBotSpecialPageEntityRepo.ts
+++ b/src/server/data-access/MwBotSpecialPageEntityRepo.ts
@@ -1,0 +1,68 @@
+import EntityRepository from '@/common/data-access/EntityRepository';
+import mwbot from 'mwbot';
+import TechnicalProblem from '@/common/data-access/error/TechnicalProblem';
+import EntityNotFound from '@/common/data-access/error/EntityNotFound';
+import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
+import EntityInitializer from '@/common/EntityInitializer';
+
+export default class MwBotSpecialPageEntityRepo implements EntityRepository {
+	private bot: mwbot;
+	private entityInitializer: EntityInitializer;
+
+	public constructor( bot: mwbot, entityInitializer: EntityInitializer ) {
+		this.bot = bot;
+		this.entityInitializer = entityInitializer;
+	}
+
+	public getFingerprintableEntity( id: string ): Promise<FingerprintableEntity> {
+		return new Promise( ( resolve, reject ) => {
+			this.getEntity( id )
+				.then( ( entity: any ) => {
+					try {
+						resolve ( this.entityInitializer.newFromSerialization( entity ) );
+					} catch ( e ) {
+						reject( new TechnicalProblem( e.message ) );
+					}
+				} )
+				.catch( ( reason ) => {
+					reject( reason );
+				} );
+		} );
+	}
+
+	private getEntity( id: string ): Promise<any> {
+		return new Promise( ( resolve, reject ) => {
+			this.bot.request( {
+			}, {
+				method: 'GET',
+				uri: this.bot.options.apiUrl.replace( '/api.php', `/index.php` ),
+				qs: {
+					title: 'Special:EntityData',
+					format: 'json',
+					id,
+					// revision: 798248942
+				},
+			} )
+				.then( ( response: any ) => {
+					if ( !( 'entities' in response ) ) {
+						reject( new TechnicalProblem( 'result not well formed.' ) );
+						return;
+					}
+
+					if ( !( id in response.entities ) ) {
+						reject( new EntityNotFound( 'result does not contain relevant entity.' ) );
+						return;
+					}
+
+					resolve( response.entities[ id ] );
+				} )
+				.catch( ( reason: any ) => {
+					if ( typeof reason.response === 'string' && reason.response.match( /Not Found/ ) ) {
+						reject( new EntityNotFound( 'Entity flagged missing in response.' ) );
+						return;
+					}
+					reject( new TechnicalProblem( reason ) );
+				} );
+		} );
+	}
+}

--- a/src/types/server/mwbot.d.ts
+++ b/src/types/server/mwbot.d.ts
@@ -1,6 +1,11 @@
 declare module 'mwbot' {
+	interface MwbotOptions {
+		apiUrl: string;
+	}
+
 	export default class mwbot {
+		public readonly options: MwbotOptions;
 		constructor( config: object );
-		request( params: object ): Promise<object>;
+		request( params: object, customRequestOptions: object = {} ): Promise<object>;
 	}
 }

--- a/tests/unit/server/data-access/MwBotSpecialPageEntityRepo.spec.ts
+++ b/tests/unit/server/data-access/MwBotSpecialPageEntityRepo.spec.ts
@@ -1,0 +1,194 @@
+import EntityInitializer from '@/common/EntityInitializer';
+import FingerprintableEntity from '@/datamodel/FingerprintableEntity';
+import MwBotSpecialPageEntityRepo from '@/server/data-access/MwBotSpecialPageEntityRepo';
+import EntityNotFound from '@/common/data-access/error/EntityNotFound';
+import TechnicalProblem from '@/common/data-access/error/TechnicalProblem';
+import mwbot from 'mwbot';
+
+function newMwBotSpecialPageEntityRepo( bot: any, initializer?: any ) {
+	bot.options = {
+		apiUrl: 'https://www.wikidata.org/wiki/api.php',
+	};
+	return new MwBotSpecialPageEntityRepo(
+		bot,
+		initializer || {},
+	);
+}
+
+describe( 'MwBotSpecialPageEntityRepo', () => {
+
+	it( 'can be constructed with mwbot', () => {
+		expect( newMwBotSpecialPageEntityRepo( new mwbot( {} ) ) )
+			.toBeInstanceOf( MwBotSpecialPageEntityRepo );
+	} );
+
+	describe( 'getFingerprintableEntity', () => {
+		it( 'creates a well-formed request', ( done ) => {
+			const entityId = 'Q42';
+			const bot = {
+				request: ( params: object, customRequestOptions: object ) => {
+					expect( params ).toEqual( {
+					} );
+					expect( customRequestOptions ).toEqual( {
+						method: 'GET',
+						uri: 'https://www.wikidata.org/wiki/index.php',
+						qs: {
+							title: 'Special:EntityData',
+							format: 'json',
+							id: entityId,
+						},
+					} );
+
+					return Promise.reject( 'This test focuses on the request.' );
+				},
+			};
+
+			const repo = newMwBotSpecialPageEntityRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( () => {
+				done();
+			} );
+		} );
+
+		it( 'resolves to an Entity on success', ( done ) => {
+			const entityId = 'Q3';
+			const entity = {
+				pageid: 3,
+				ns: 120,
+				title: 'Item:Q3',
+				lastrevid: 1149,
+				modified: '2018-07-06T10:41:48Z',
+				type: 'item',
+				id: 'Q3',
+				labels: {
+					en: { language: 'en', value: 'potato' },
+					de: { language: 'de', value: 'Kartoffel' },
+				},
+				descriptions: {
+					en: { language: 'en', value: 'a root vegetable' },
+					de: { language: 'de', value: 'ein Wurzelgemüse' },
+				},
+				aliases: {
+					en: [
+						{ language: 'en', value: 'Spud' },
+					],
+				},
+				claims: {},
+				sitelinks: {},
+			};
+			const results = {
+				entities: {
+					Q3: entity,
+				},
+			};
+			const bot = {
+				request: () => {
+					return Promise.resolve( results );
+				},
+			};
+
+			const repo = newMwBotSpecialPageEntityRepo( bot, new EntityInitializer() );
+			repo.getFingerprintableEntity( entityId ).then( ( result: FingerprintableEntity ) => {
+				expect( result ).toBeInstanceOf( FingerprintableEntity );
+				expect( result.id ).toEqual( entity.id );
+				expect( result.labels ).toEqual( entity.labels );
+				expect( result.descriptions ).toEqual( entity.descriptions );
+				expect( result.aliases ).toEqual( entity.aliases );
+				done();
+			} );
+		} );
+
+		it( 'rejects on result missing entities key', ( done ) => {
+			const entityId = 'Q3';
+			const bot = {
+				request: () => {
+					return Promise.resolve( {} );
+				},
+			};
+			const repo = newMwBotSpecialPageEntityRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( TechnicalProblem );
+				expect( reason.message ).toEqual( 'result not well formed.' );
+				done();
+			} );
+		} );
+
+		it( 'rejects on result missing relevant entity in entities', ( done ) => {
+			const entityId = 'Q3';
+			const bot = {
+				request: () => {
+					return Promise.resolve( {
+						entities: {
+							Q4: {
+								irrelevant: 'value',
+							},
+						},
+					} );
+				},
+			};
+			const repo = newMwBotSpecialPageEntityRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( EntityNotFound );
+				expect( reason.message ).toEqual( 'result does not contain relevant entity.' );
+				done();
+			} );
+		} );
+
+		it( 'rejects on result indicating relevant entity as missing', ( done ) => {
+			const entityId = 'Q3';
+			const bot = {
+				request: () => {
+					return Promise.reject( {
+						response: 'something something <h1>Not Found</h1> something',
+					} );
+				},
+			};
+			const repo = newMwBotSpecialPageEntityRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( EntityNotFound );
+				expect( reason.message ).toEqual( 'Entity flagged missing in response.' );
+				done();
+			} );
+		} );
+
+		it( 'rejects stating the reason in case of API problems', ( done ) => {
+			const entityId = 'Q3';
+			const bot = {
+				request: () => {
+					return Promise.reject( new Error( 'invalidjson: No valid JSON response' ) );
+				},
+			};
+			const repo = newMwBotSpecialPageEntityRepo( bot );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( TechnicalProblem );
+				expect( reason.message ).toEqual( 'Error: invalidjson: No valid JSON response' );
+				done();
+			} );
+		} );
+
+		it( 'rejects stating the technical reason in case of entity initialization problem', ( done ) => {
+			const entityId = 'Q3';
+			const bot = {
+				request: () => {
+					return Promise.resolve( {
+						entities: {
+							Q3: {
+								id: 'Q3',
+							},
+						},
+					} );
+				},
+			};
+			const initializer = {
+				newFromSerialization: () => {
+					throw new Error( 'initializer sad' );
+				},
+			};
+			const repo = newMwBotSpecialPageEntityRepo( bot, initializer );
+			repo.getFingerprintableEntity( entityId ).catch( ( reason: Error ) => {
+				expect( reason ).toBeInstanceOf( TechnicalProblem );
+				expect( reason.message ).toEqual( 'initializer sad' );
+				done();
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
Allow for requests against Special:EntityData, e.g.
https://www.wikidata.org/wiki/Special:EntityData/Q64.json?format=json
to satisfy EntityRepository.

This needs the special page URL configurable.

Bug: T212196