### PR TITLE
tests: throw in case we encounter unhandled promise rejection

### DIFF
--- a/tests/config/setup.ts
+++ b/tests/config/setup.ts
@@ -1,3 +1,15 @@
 beforeEach( () => {
 	expect.hasAssertions();
 } );
+
+// Break on unhandled promise rejection (default warning might be overlooked)
+// https://github.com/facebook/jest/issues/3251#issuecomment-299183885
+// However...
+// https://stackoverflow.com/questions/51957531/jest-how-to-throw-an-error-inside-a-unhandledrejection-handler
+if ( typeof process.env.LISTENING_TO_UNHANDLED_REJECTION === 'undefined' ) {
+	process.on( 'unhandledRejection', ( unhandledRejectionWarning ) => {
+		throw unhandledRejectionWarning; // see stack trace for test at fault
+	} );
+	// Avoid memory leak by adding too many listeners
+	process.env.LISTENING_TO_UNHANDLED_REJECTION = 'yes';
+}

--- a/tests/unit/client/init.spec.ts
+++ b/tests/unit/client/init.spec.ts
@@ -18,7 +18,11 @@ function mockMwEnv( language: string, entityId: any, namespaces: any = null, tit
 			}
 		} },
 		hook: () => new ImmediatelyInvokingEntityLoadedHookHandler( {} ),
-		Title: title || jest.fn().mockImplementation(),
+		Title: title || jest.fn().mockImplementation( () => {
+			return {
+				getUrl: jest.fn(),
+			};
+		} ),
 	};
 }
 


### PR DESCRIPTION
As opposed to just showing a warning that might get eaten in cli when
multple jest child processes work in parallel.
See https://github.com/facebook/jest/issues/3251
This is a bit unsatifactory as it makes the parent jest process hang in
case there are such occurances.

Should be green again with #133

Bug: T212409