### PR TITLE
tests: ensure init.spec mocks used getUrl method

### DIFF
--- a/tests/unit/client/init.spec.ts
+++ b/tests/unit/client/init.spec.ts
@@ -18,7 +18,11 @@ function mockMwEnv( language: string, entityId: any, namespaces: any = null, tit
 			}
 		} },
 		hook: () => new ImmediatelyInvokingEntityLoadedHookHandler( {} ),
-		Title: title || jest.fn().mockImplementation(),
+		Title: title || jest.fn().mockImplementation( () => {
+			return {
+				getUrl: jest.fn(),
+			};
+		} ),
 	};
 }
 


### PR DESCRIPTION
Previously, the used method was not mocked which caused the test to
result in an unhandled promise - and as this was only a warning it
stayed green.

Goes into #132

Bug: T212409