### PR TITLE
Use conventional test syntax instead of magic "resolves"

### DIFF
--- a/tests/unit/client/init.spec.ts
+++ b/tests/unit/client/init.spec.ts
@@ -33,7 +33,9 @@ describe( 'client/init', () => {
 		const termboxRequestPromise = init();
 
 		expect( termboxRequestPromise ).toBeInstanceOf( Promise );
-		expect( termboxRequestPromise ).resolves.toBeInstanceOf( TermboxRequest );
+		return termboxRequestPromise.then( ( request ) => {
+			expect( request ).toBeInstanceOf( TermboxRequest );
+		} );
 	} );
 
 	it( 'generates a TermboxRequest from the mw environment', () => {


### PR DESCRIPTION
Since there was another assertion in the test, and it did not actively
wait for the promise to be resolved, the test passed without evaluating
the second assertion.