### PR TITLE
Provide a way to test rtl languages in dev mode.

### DIFF
--- a/src/mock-data/MwConfig.ts
+++ b/src/mock-data/MwConfig.ts
@@ -1,7 +1,7 @@
 export default class MWConfig {
 	public get( key: string ): any {
 		const config: { [ index: string ]: any } = {
-			wgUserLanguage: 'de',
+			wgUserLanguage: ( new URLSearchParams( location.search ) ).get( 'uselang' ) || 'de',
 			wbEntityId: 'Q64',
 			wgNamespaceIds: { special: -1 },
 		};

--- a/src/mock-data/MwConfig.ts
+++ b/src/mock-data/MwConfig.ts
@@ -1,7 +1,13 @@
 export default class MWConfig {
+	private language: string;
+
+	public constructor( language: string ) {
+		this.language = language;
+	}
+
 	public get( key: string ): any {
 		const config: { [ index: string ]: any } = {
-			wgUserLanguage: ( new URLSearchParams( location.search ) ).get( 'uselang' ) || 'de',
+			wgUserLanguage: this.language,
 			wbEntityId: 'Q64',
 			wgNamespaceIds: { special: -1 },
 		};

--- a/src/mock-data/getOrEnforceUrlParameter.ts
+++ b/src/mock-data/getOrEnforceUrlParameter.ts
@@ -1,0 +1,17 @@
+/**
+ * Get the value of the current (i.e. in browser) URL's GET param
+ * or redirect to the given default value if not present
+ *
+ * @param name string
+ * @param defaultValue string
+ */
+export default function( name: string, defaultValue: string ): string {
+	const searchParams = new URLSearchParams( location.search );
+	const value = searchParams.get( name );
+	if ( value === null || value.trim() === '' ) {
+		searchParams.set( name, defaultValue );
+		window.open( '?' + searchParams.toString(), '_self' );
+		return;
+	}
+	return value;
+}

--- a/src/mockup-entry.ts
+++ b/src/mockup-entry.ts
@@ -5,11 +5,14 @@ import * as languageMap from '@/mock-data/data/en_lang_data.json';
 import * as directionalities from '@/mock-data/data/en_lang_dir_data.json';
 import ImmediatelyInvokingEntityLoadedHookHandler from '@/mock-data/ImmediatelyInvokingEntityLoadedHookHandler';
 import MwWindow from '@/client/mediawiki/MwWindow';
+import getOrEnforceUrlParameter from './mock-data/getOrEnforceUrlParameter';
+
+const language = getOrEnforceUrlParameter( 'language', 'de' );
 
 /* tslint:disable:max-classes-per-file */
 
 ( window as MwWindow ).mw = {
-	config: new MWConfig(),
+	config: new MWConfig( language ),
 	hook: () => new ImmediatelyInvokingEntityLoadedHookHandler( entity ),
 	Title: class Title { public getUrl() { return '/edit/' + entity.id; } },
 };


### PR DESCRIPTION
This makes it possible to try out the termbox in languages other than `de` by appending `?uselang=ar` for example.