### PR TITLE
Show language used in dev mode in URL in older browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14718,6 +14718,12 @@
         "prepend-http": "^1.0.1"
       }
     },
+    "url-search-params-polyfill": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-5.0.0.tgz",
+      "integrity": "sha512-+SCD22QJp4UnqPOI5UTTR0Ljuh8cHbjEf1lIiZrZ8nHTlTixqwVsVQTSfk5vrmDz7N09/Y+ka5jQr0ff35FnQQ==",
+      "dev": true
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "supertest": "^3.3.0",
     "ts-jest": "^23.10.5",
     "typescript": "^3.2.2",
+    "url-search-params-polyfill": "^5.0.0",
     "vue-template-compiler": "^2.5.21"
   }
 }

--- a/src/mock-data/getOrEnforceUrlParameter.ts
+++ b/src/mock-data/getOrEnforceUrlParameter.ts
@@ -1,3 +1,5 @@
+import 'url-search-params-polyfill';
+
 /**
  * Get the value of the current (i.e. in browser) URL's GET param
  * or redirect to the given default value if not present


### PR DESCRIPTION
Older browsers, i.e. IE10, may not natively support URLSearchParams
This is only relevant for the development preview.
Follow-up for #143