### PR TITLE
debugging: log server errors to console

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -46,7 +46,8 @@ export default ( WIKIBASE_REPO_API: string ) => {
 						response.status( HttpStatus.BAD_REQUEST ).send( 'Bad request. Language not existing' );
 					}
 				} else {
-					response.status( HttpStatus.INTERNAL_SERVER_ERROR ).send( 'Technical problem ' + JSON.stringify( err ) );
+					response.status( HttpStatus.INTERNAL_SERVER_ERROR ).send( 'Technical problem' );
+					console.log( err );
 				}
 			} );
 	} );


### PR DESCRIPTION
Log - not otherwise explicitly handled - errors to console
(i.e. stdout) to be able to debug.
This also omits potential security problems that could arise from
sending stack traces to browsers during technical problems.
Could be worthwile to do this conditionally based on env, or even
implement some logger that facilitates a centralized logging
infrastructure for prod.