### PR TITLE
fix e2e test challenges

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -8,19 +8,13 @@ import HttpStatus from 'http-status-codes';
 import BundleBoundaryPassingException, { ErrorReason } from './exceptions/BundleBoundaryPassingException';
 import BundleRendererServices from './bundle-renderer/BundleRendererServices';
 import BundleRendererContextBuilder from './bundle-renderer/BundleRendererContextBuilder';
-import mwbot from 'mwbot';
 
-export default ( WIKIBASE_REPO_API: string ) => {
+export default ( services: BundleRendererServices ) => {
 
 	const app = express();
 	const renderer = createBundleRenderer(
 		resolve( './serverDist/vue-ssr-server-bundle.json' ),
 		{ runInNewContext: false },
-	);
-	const services = new BundleRendererServices(
-		new mwbot( {
-			apiUrl: WIKIBASE_REPO_API,
-		} ),
 	);
 	const contextBuilder = new BundleRendererContextBuilder( services );
 
@@ -47,7 +41,7 @@ export default ( WIKIBASE_REPO_API: string ) => {
 					}
 				} else {
 					response.status( HttpStatus.INTERNAL_SERVER_ERROR ).send( 'Technical problem' );
-					console.log( err );
+					services.logger.log( err );
 				}
 			} );
 	} );

--- a/src/server/bundle-renderer/BundleRendererServices.ts
+++ b/src/server/bundle-renderer/BundleRendererServices.ts
@@ -1,9 +1,15 @@
 import mwbot from 'mwbot';
 
+interface Logger {
+	log( ...things: any[] ): void;
+}
+
 export default class BundleRendererServices {
 	public readonly mediawikiBot: mwbot;
+	public readonly logger: Logger;
 
-	public constructor( mediawikiBot: mwbot ) {
+	public constructor( mediawikiBot: mwbot, logger: Logger ) {
 		this.mediawikiBot = mediawikiBot;
+		this.logger = logger;
 	}
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,5 +1,7 @@
 import 'module-alias/register';
 import createApp from './app';
+import BundleRendererServices from './bundle-renderer/BundleRendererServices';
+import mwbot from 'mwbot';
 
 function verifyAndReportSetting( name: string, value: any ) {
 	if ( typeof value === 'undefined' ) {
@@ -13,7 +15,14 @@ function verifyAndReportSetting( name: string, value: any ) {
 verifyAndReportSetting( 'WIKIBASE_REPO_API', process.env.WIKIBASE_REPO_API );
 verifyAndReportSetting( 'SSR_PORT', process.env.SSR_PORT );
 
-createApp( process.env.WIKIBASE_REPO_API as string )
+const services = new BundleRendererServices(
+	new mwbot( {
+		apiUrl: process.env.WIKIBASE_REPO_API,
+	} ),
+	console,
+);
+
+createApp( services )
 	.listen( process.env.SSR_PORT, () => {
 		console.info( `server is now running...` );
 	} );

--- a/tests/edge-to-edge/server/app.spec.ts
+++ b/tests/edge-to-edge/server/app.spec.ts
@@ -110,6 +110,8 @@ describe( 'Termbox SSR', () => {
 		const language = 'de';
 		const editLink = '/some/' + entityId;
 
+		nockSuccessfulLanguageLoading( language );
+		nockSuccessfulMessagesLoading( language );
 		nock( WIKIBASE_TEST_API_HOST )
 			.post( WIKIBASE_TEST_API_PATH + '?format=json', {
 				ids: entityId,
@@ -131,6 +133,8 @@ describe( 'Termbox SSR', () => {
 		const language = 'de';
 		const editLink = '/some';
 
+		nockSuccessfulLanguageLoading( language );
+		nockSuccessfulMessagesLoading( language );
 		nock( WIKIBASE_TEST_API_HOST )
 			.post( WIKIBASE_TEST_API_PATH + '?format=json', {
 				ids: entityId,
@@ -159,6 +163,7 @@ describe( 'Termbox SSR', () => {
 				uselang: language,
 			} )
 			.reply( HttpStatus.INTERNAL_SERVER_ERROR, 'upstream system error' );
+		nockSuccessfulMessagesLoading( language );
 		nockSuccessfulEntityLoading( entityId );
 
 		request( app ).get( '/termbox' ).query( { entity: entityId, language, editLink } ).then( ( response ) => {

--- a/tests/unit/server/bundle-renderer/BundleRendererContext.spec.ts
+++ b/tests/unit/server/bundle-renderer/BundleRendererContext.spec.ts
@@ -5,7 +5,10 @@ import mwbot from 'mwbot';
 
 describe( 'BundleRendererContext', () => {
 	it( 'can be constructed and assigns properties', () => {
-		const services = new BundleRendererServices( new mwbot( {} ) );
+		const services = new BundleRendererServices(
+			new mwbot( {} ),
+			{ log: () => {} },
+		);
 		const request = new TermboxRequest( 'Q71', 'de', '/edit/Q4711' );
 
 		const context = new BundleRendererContext(

--- a/tests/unit/server/bundle-renderer/BundleRendererContextBuilder.spec.ts
+++ b/tests/unit/server/bundle-renderer/BundleRendererContextBuilder.spec.ts
@@ -15,6 +15,7 @@ describe( 'BundleRendererContextBuilder', () => {
 				new mwbot( {
 					apiUrl: 'http://mywiki.com/api.php',
 				} ),
+				{ log: () => {} },
 			);
 			const request = new TermboxRequest( 'Q71', 'de', '/edit/Q4711' );
 

--- a/tests/unit/server/bundle-renderer/BundleRendererServices.spec.ts
+++ b/tests/unit/server/bundle-renderer/BundleRendererServices.spec.ts
@@ -4,11 +4,13 @@ import mwbot from 'mwbot';
 describe( 'BundleRendererServices', () => {
 	it( 'can be constructed and assigns properties', () => {
 		const bot = new mwbot( {} );
+		const logger = { log: () => {} };
 
-		const services = new BundleRendererServices( bot );
+		const services = new BundleRendererServices( bot, logger );
 
 		expect( services ).toBeInstanceOf( BundleRendererServices );
-		expect( services.mediawikiBot ).toEqual( bot );
+		expect( services.mediawikiBot ).toBe( bot );
+		expect( services.logger ).toBe( logger );
 	} );
 
 } );


### PR DESCRIPTION
Overcome two problems in e2e tests
* e5068d4
  In 3 places, backend requests that are actually performed were not mocked
* 2d92121
  Make the logger used by the server-side application configurable so it does not spill to stdout during e2e tests - could also be useful in production when hooking up something more elaborate (then we should probably assert how the logger communicates its findings to the outside rather than what it receives as input)

If anyone is worried about calling this e2e after the latter change let's quickly discuss how we solve this.