### PR TITLE
server: react to SIGINT

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -26,3 +26,8 @@ createApp( services )
 	.listen( process.env.SSR_PORT, () => {
 		console.info( `server is now running...` );
 	} );
+
+process.on( 'SIGINT', () => {
+	console.info( 'Process received SIGINT' );
+	process.exit( 0 );
+} );


### PR DESCRIPTION
To be able to stop the process through ctrl+c (SIGINT) when running
the server built for production (via `docker(-compose) run`).
Probably will be replaced by a more elaborate solution when looking
into graceful shutdown.
See
https://expressjs.com/en/advanced/healthcheck-graceful-shutdown.html
https://github.com/godaddy/terminus

Bug: T211675